### PR TITLE
Create chapterimg environment to avoid duplicated code for setting up chapter images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: teatimeguest/setup-texlive-action@v2
       - name: install xelatex and dependencies
         run: |
-          sudo apt-get install inkscape texlive-xetex texlive-lang-portuguese latexmk
+          sudo apt-get install inkscape texlive-xetex texlive-lang-portuguese
       - name: install project fonts
         run: |
           ./scripts/install-font.sh "Gentium Book Plus" "EB Garamond"

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,15 @@
 OUTDIR = out
-TEX = latexmk
-TEXARGS = -output-directory=$(OUTDIR) -shell-escape -xelatex
+TEX = xelatex
+TEXARGS = -output-directory=$(OUTDIR) -shell-escape
 DEPS = $(wildcard *.tex blocks/*.tex)
 
 .PHONY: all
 all: $(OUTDIR)/main.pdf
 
 $(OUTDIR)/%.pdf: %.tex $(DEPS) | $(OUTDIR)
-	@$(TEX) $(TEXARGS) $<
+	# runs twice, to aways ensure TOC is properly generated
+	@$(TEX) $(TEXARGS) $< -o $@
+	@$(TEX) $(TEXARGS) $< -o $@
 
 $(OUTDIR):
 	@mkdir -p $@

--- a/blocks/akathist-sweetest-lord-jesus-christ.tex
+++ b/blocks/akathist-sweetest-lord-jesus-christ.tex
@@ -2,11 +2,9 @@
 
 \begin{document}
 
-\cleardoubleevenpage{}
-\pagestyle{empty}
-\includesvg[width=\textwidth]{icons/transfiguration}
-\chapter{Acatiste ao Nosso Dulcíssimo Senhor Jesus Cristo}
-\pagestyle{headings}
+\begin{chapterimg}[width=\textwidth]{icons/transfiguration}
+    \chapter{Acatiste ao Nosso Dulcíssimo Senhor Jesus Cristo}
+\end{chapterimg}
 
 \section*{Kontákion 1}
 

--- a/blocks/akathist-theotokos.tex
+++ b/blocks/akathist-theotokos.tex
@@ -2,11 +2,9 @@
 
 \begin{document}
 
-\cleardoubleevenpage{}
-\pagestyle{empty}
-\includesvg[width=\textwidth]{icons/platytera}
-\chapter{Acatiste à Mãe de Deus}
-\pagestyle{headings}
+\begin{chapterimg}[width=\textwidth]{icons/platytera}
+    \chapter{Acatiste à Mãe de Deus}
+\end{chapterimg}
 
 \section*{Kontákion 1, tom 8}
 

--- a/blocks/canon-guardian-angel.tex
+++ b/blocks/canon-guardian-angel.tex
@@ -1,11 +1,9 @@
 \documentclass{subfiles}
 \begin{document}
 
-\cleardoubleevenpage{}
-\pagestyle{empty}
-\includesvg[width=\textwidth]{icons/st-michael}
-\chapter{Cânone ao Anjo Guardião}
-\pagestyle{headings}
+\begin{chapterimg}[width=.9\textwidth]{icons/st-michael}
+    \chapter{Cânone ao Anjo Guardião}
+\end{chapterimg}
 
 \section*{Tropário, Tom 6}
 

--- a/blocks/matins.tex
+++ b/blocks/matins.tex
@@ -2,10 +2,9 @@
 
 \begin{document}
 
-\pagestyle{empty}
-{\centering\includesvg[height=\textheight]{icons/tree-of-life-cross}}
-\Chapter{Orações Matinais}{}
-\pagestyle{headings}
+\begin{chapterimg}[height=.9\textheight]{icons/tree-of-life-cross}
+    \Chapter{Orações Matinais}{}
+\end{chapterimg}
 
 \dotextit{%
 Tendo despertado do sono, antes de qualquer outra ação, levante-se 

--- a/blocks/supplicatory-canon-christ.tex
+++ b/blocks/supplicatory-canon-christ.tex
@@ -1,10 +1,9 @@
 \documentclass{subfiles}
 \begin{document}
 
-\pagestyle{empty}
-{\centering\includesvg[height=\textheight]{icons/crucifixion}}
-\Chapter{Canône de Arrependimento}{A Nosso Senhor Jesus Cristo}
-\pagestyle{headings}
+\begin{chapterimg}[height=\textheight]{icons/crucifixion}
+    \Chapter{Canône de Arrependimento}{A Nosso Senhor Jesus Cristo}
+\end{chapterimg}
 
 \section*{ODE 1, Tom 2}
 

--- a/blocks/supplicatory-canon-theotokos.tex
+++ b/blocks/supplicatory-canon-theotokos.tex
@@ -1,10 +1,9 @@
 \documentclass{subfiles}
 \begin{document}
 
-\pagestyle{empty}
-\includesvg[width=\textwidth]{icons/hail-full-of-grace}
-\Chapter{Canône de Súplica}{À Santíssima Mãe de Deus}
-\pagestyle{headings}
+\begin{chapterimg}[width=\textwidth]{icons/hail-full-of-grace}
+    \Chapter{Canône de Súplica}{À Santíssima Mãe de Deus}
+\end{chapterimg}
 
 \section*{Tropário, tom 4}
 

--- a/main.tex
+++ b/main.tex
@@ -172,7 +172,7 @@ cura, pelo Teu Nome, as nossas enfermidades e visita-nos.}
 \raggedbottom{}
 
 \tableofcontents{}
-\pagebreak{}
+\cleardoubleevenpage{}
 \pagestyle{headings}
 
 \subfile{blocks/matins.tex}

--- a/main.tex
+++ b/main.tex
@@ -39,6 +39,14 @@
     \def\param{#1}%
     \ifx\param\empty}
 
+\newenvironment{chapterimg}[2][]{%
+    \pagestyle{empty}
+    \ifthispageodd{}{\cleardoubleevenpage{}}
+    {\vspace*{\fill}%
+     \centering\includesvg[#1]{#2}%
+     \vspace*{\fill}}}
+    {\pagestyle{headings}}
+
 % stylization of chapters and sections =========================================
 
 \RedeclareSectionCommand[


### PR DESCRIPTION
# Summary

* Chapter images were configured ad hoc, and a lot of code was duplicated;
* An environment was created to wrap chapter declarations that includes a SVG
    and accepts parameters to be passed to `\includesvg`, like height, width
    etc.;
    * The environment is smart to know when to clear pages to always have
        chapter images in even pages, and chapter headings in odd pages.
